### PR TITLE
Dump chems

### DIFF
--- a/app/pages/sell-chem/sell-chem.html
+++ b/app/pages/sell-chem/sell-chem.html
@@ -5,16 +5,27 @@
 </ion-navbar>
 
 <ion-content padding class="bg-light">
-  <h2>{{chem.name}} @ {{chem.currentPrice}} caps</h2>
-  <p *ngIf="getProfitMargin() != null">
-    Profit Margin: {{getProfitMargin()}} %
-  </p>
-  <p *ngIf="getProfitMargin() == null">
-    You didn't even pay for these chems...sweet
-  </p>
-  <p *ngIf="player.guards > 0">
-    Guard Share: {{getGuardsShare()}} caps
-  </p>
+  <div *ngIf="chem.currentPrice < 0">
+    <h2>{{chem.name}}</h2>
+    <p>
+      <b>Warning</b>: {{chem.name}} is not sold here!
+    </p>
+    <p>
+      You're dumping your {{chem.name}} if you sell.
+    </p>
+  </div>
+  <div *ngIf="chem.currentPrice > 0">
+    <h2>{{chem.name}} @ {{chem.currentPrice}} caps</h2>
+    <p *ngIf="getProfitMargin() != null">
+      Profit Margin: {{getProfitMargin()}} %
+    </p>
+    <p *ngIf="getProfitMargin() == null">
+      You didn't even pay for these chems...sweet
+    </p>
+    <p *ngIf="player.guards > 0">
+      Guard Share: {{getGuardsShare()}} caps
+    </p>
+  </div>
 
   <div class="spacer">
     <span></span>
@@ -28,7 +39,10 @@
       <ion-label range-right>{{maxSellable}}</ion-label>
     </ion-range>
   </ion-item>
-  <button block (click)="sell()">
+  <button block *ngIf="chem.currentPrice > 0" (click)="sell()">
     Sell for {{quantity * chem.currentPrice}} caps
+  </button>
+  <button block *ngIf="chem.currentPrice < 0" (click)="dump()">
+    Dump {{quantity}} {{chem.name}}
   </button>
 </ion-content>

--- a/app/pages/sell-chem/sell-chem.ts
+++ b/app/pages/sell-chem/sell-chem.ts
@@ -34,6 +34,12 @@ export class SellChemPage {
     this.nav.pop();
   }
 
+  dump(): void {
+    this.player.inventory.removeChem(this.chem, this.quantity);
+    this.sqlService.savePlayerState(this.player);
+    this.nav.pop();
+  }
+
   getProfitMargin(): number {
     if (this.player.pricePaid(this.chem) > 0) {
       //return the profit margin percentage rounded to two deciml places

--- a/app/pages/settlement-page/settlement-page.html
+++ b/app/pages/settlement-page/settlement-page.html
@@ -25,13 +25,15 @@
       <ion-row>
         <ion-col width-33 class="no-vertical-padding">
           <h4 dark>{{chem.name}}</h4>
-          <p dark>{{chem.currentPrice}} caps</p>
+          <p dark *ngIf="chem.currentPrice > 0">{{chem.currentPrice}} caps</p>
           <p dark *ngIf="player.quantityCarrying(chem) > 0">
               {{player.pricePaid(chem)}} avg. paid
           </p>
         </ion-col>
         <ion-col width-33 class="no-vertical-padding">
-          <button block (click)="buy(chem)">Buy</button>
+          <button block (click)="buy(chem)" [disabled]="chem.currentPrice < 0">
+            Buy
+          </button>
         </ion-col>
         <ion-col width-33 class="no-vertical-padding">
           <button danger block (click)="sell(chem)" 

--- a/app/pages/settlement-page/settlement-page.ts
+++ b/app/pages/settlement-page/settlement-page.ts
@@ -50,6 +50,11 @@ export class SettlementPage {
 			if (playerState) {
 				let playerShadow = JSON.parse(playerState);
 				this.player = new Player(playerShadow.name, playerShadow);
+        //filter out any dumped chems
+        this.availableChems = this.availableChems.filter((chem) => {
+          let playerChems = this.player.inventory.getChemList();
+          return chem.currentPrice > 0 || (chem.name in playerChems);
+        });
 			}
 		}, function(error) {
 			console.error('Failed to load player state', error);

--- a/app/pages/settlement-page/settlement-page.ts
+++ b/app/pages/settlement-page/settlement-page.ts
@@ -37,6 +37,7 @@ export class SettlementPage {
     this.player.location = this.settlement.index;
     this.sqlService.savePlayerState(this.player);
     this.availableChems = chemService.generateChemSet();
+    this.addPlayerChemsNotForSale();
     this.priceAlertMessages = this.generatePriceModifiers();
 	}
 
@@ -130,6 +131,15 @@ export class SettlementPage {
       }
     }
     return modifierMessages;
+  }
+
+  addPlayerChemsNotForSale(): void {
+    for (let chemName in this.player.inventory.getChemList()) {
+      if (this.availableChems.find(
+        (chem) => { return chem.name == chemName; }) == undefined) {
+        this.availableChems.push(new Chem(chemName, 0, 0, '', '', -1));
+      }
+    }
   }
 }
 

--- a/app/providers/classes/chem.ts
+++ b/app/providers/classes/chem.ts
@@ -7,10 +7,10 @@ export class Chem {
   lowPriceMessage: string;
 
   constructor(name: string, basePrice: number, probability: number,
-              high: string, low: string) {
+              high: string, low: string, currentPrice?: number) {
     this.name = name;
     this.basePrice = basePrice;
-    this.currentPrice = basePrice;
+    this.currentPrice = currentPrice | basePrice;
     this.probability = probability;
     this.highPriceMessage = high;
     this.lowPriceMessage = low;

--- a/app/providers/classes/inventory.ts
+++ b/app/providers/classes/inventory.ts
@@ -7,6 +7,10 @@ export class Inventory {
     this.chems = {};
   }
 
+  getChemList(): { [chem: string]: { quantity: number, price_paid: number } }  {
+    return this.chems;
+  }
+
   getQuantity(chem: Chem): number {
     if (chem.name in this.chems) {
       return this.chems[chem.name].quantity;


### PR DESCRIPTION
Fixes #22 
- Player is now able to dump chems they are carrying that are not for sale at the current settlement. 
- Dumpable chems will appear at the bottom of the chem list with disabled buy buttons
- Sell page will warn player that they are dumping chems
- If a player dumps all inventory for a particular chem, it will be removed from the list
